### PR TITLE
将本地版本发布到远程端命令错误,应是 `git push <remote_name> <remote_branch_name>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ git pull --rebase <remote> <branch>
 
 ##### 将本地版本发布到远程端：
 ```
-$ git push remote <remote> <branch>
+$ git push <remote> <branch>
 ```
 
 ##### 删除远程端分支：


### PR DESCRIPTION
将本地版本发布到远程端命令错误,应是 `git push <remote_name> <remote_branch_name>`